### PR TITLE
removes mid-download file compitibility to improve readability

### DIFF
--- a/mibi_bin_tools/_extract_bin.pyx
+++ b/mibi_bin_tools/_extract_bin.pyx
@@ -42,38 +42,8 @@ cdef inline int _minimum_larger_value_in_sorted(const DTYPE_t[:] low_range, DTYP
 @boundscheck(False) # Deactivate bounds checking
 @wraparound(False)  # Deactivate negative indexing
 @cdivision(True) # Ignore modulo/divide by zero warning
-cdef inline void _fread_downloading(char *file_buffer, size_t num_bytes, MAXINDEX_t buffer_size, 
-                                    FILE* fp, int timeout, MAXINDEX_t *curr_file_size,
-                                    MAXINDEX_t filesize):
-    """ moddification of fread to await file download completion
-    """
-
-    cdef MAXINDEX_t offset
-    offset = ftell(fp)
-    if buffer_size <= curr_file_size[0] - offset or curr_file_size[0] == filesize:
-        fread(file_buffer, num_bytes, buffer_size, fp)
-        return
-    cdef int timer = 0
-    while True:
-        fseek(fp, 0, SEEK_END)
-        curr_file_size[0] = ftell(fp)
-        clearerr(fp)
-        if buffer_size <= curr_file_size[0] - offset:
-            break
-        elif timer > timeout and timeout >= 0:
-            raise FileNotFoundError('Download timeout was exceeded...')
-        timer += 1
-        usleep(1)
-    fseek(fp, offset, SEEK_SET)
-    fread(file_buffer, num_bytes, buffer_size, fp)
-
-
-@boundscheck(False) # Deactivate bounds checking
-@wraparound(False)  # Deactivate negative indexing
-@cdivision(True) # Ignore modulo/divide by zero warning
 cdef inline void _check_buffer_refill(FILE* fp, char* file_buffer, MAXINDEX_t *buffer_idx,
-                                      MAXINDEX_t read_size, MAXINDEX_t BUFFER_SIZE, int timeout, 
-                                      MAXINDEX_t *curr_file_size, MAXINDEX_t filesize):
+                                      MAXINDEX_t read_size, MAXINDEX_t BUFFER_SIZE): 
     """ Makes sure requested data is loaded into buffer
     
     Otherwise, the buffer is refilled and the offest pointer (buffer_idx) is updated.
@@ -89,12 +59,6 @@ cdef inline void _check_buffer_refill(FILE* fp, char* file_buffer, MAXINDEX_t *b
             Requested size of buffer read
         BUFFER_SIZE (uint64_t):
             Size of file buffer array
-        timeout (int):
-            How long to wait for file download (ms)
-        curr_file_size (uint64_t *t):
-            Current size of the downloading file
-        filesize (uint64_t):
-            Expected/final size of the file
     """
     # note, `buffer_idx[0]` is a cython altrenative to `*buffer_idx = 0`
     cdef MAXINDEX_t i
@@ -107,9 +71,7 @@ cdef inline void _check_buffer_refill(FILE* fp, char* file_buffer, MAXINDEX_t *b
         # this might be faster
         #memcpy(file_buffer, file_buffer + buffer_idx[0], sizeof(char) * i)
 
-        _fread_downloading(file_buffer + i, sizeof(char), BUFFER_SIZE - i, fp, timeout,
-                           curr_file_size, filesize)
-
+        fread(file_buffer + i, sizeof(char), BUFFER_SIZE - i, fp) 
         buffer_idx[0] = 0
     return
 
@@ -117,29 +79,25 @@ cdef inline void _check_buffer_refill(FILE* fp, char* file_buffer, MAXINDEX_t *b
 @boundscheck(False) # Deactivate bounds checking
 @wraparound(False)  # Deactivate negative indexing
 @cdivision(True) # Ignore modulo/divide by zero warning
-cdef INT_t[:, :, :, :] _extract_bin(const char* filename, MAXINDEX_t filesize,
+cdef INT_t[:, :, :, :] _extract_bin(const char* filename, 
                                     const DTYPE_t[:] low_range, const DTYPE_t[:] high_range,
-                                    const SMALL_t[:] calc_intensity, int timeout):
+                                    const SMALL_t[:] calc_intensity):
     """ Extracts bin file to single channel tifs
 
     Args:
         filename (const char*):
             Name of bin file to extract
-        filesize (uint64_t):
-            Expected size of bin file
         low_range (uint16_t[]):
             Starting integration ranges for each tif
         high_range (uint16_t[]):
             Stoping integration ranges for each tif
         calc_intensity (bool):
             Calculate intensity and intensity*width images.  Not implemented.
-        timeout (int):
-            How long to wait for file download (ms)
     """
     cdef DTYPE_t num_x, num_y, num_trig, num_frames, desc_len, trig, num_pulses, pulse, time
     cdef DTYPE_t intensity
     cdef SMALL_t width
-    cdef MAXINDEX_t data_start, pix, curr_file_size
+    cdef MAXINDEX_t data_start, pix 
     cdef int idx
 
     # 10MB buffer
@@ -150,19 +108,7 @@ cdef INT_t[:, :, :, :] _extract_bin(const char* filename, MAXINDEX_t filesize,
     # open file
     cdef FILE* fp
     cdef int timer = 0
-    while True:
-        fp = fopen(filename, "rb")
-        if fp != NULL:
-            timer = 0
-            break
-        elif timer > timeout and timeout >= 0:
-            raise FileNotFoundError('Timer exceeded timeout of ' + str(timeout) +' seconds')
-        timer += 1
-        usleep(1)
-
-    fseek(fp, 0, SEEK_END)
-    curr_file_size = ftell(fp)
-    fseek(fp, 0, SEEK_SET)
+    fp = fopen(filename, "rb")
 
     # note, if cython has packed structs, this would be easier
     # or even macros tbh
@@ -191,13 +137,11 @@ cdef INT_t[:, :, :, :] _extract_bin(const char* filename, MAXINDEX_t filesize,
         #if pix % num_x == 0:
         #    print('\rpix done: ' + str(100 * pix / num_x / num_y) + '%...', end='')
         for trig in range(num_trig):
-            _check_buffer_refill(fp, file_buffer, &buffer_idx, 0x8 * sizeof(char), BUFFER_SIZE,
-                                 timeout, &curr_file_size, filesize)
+            _check_buffer_refill(fp, file_buffer, &buffer_idx, 0x8 * sizeof(char), BUFFER_SIZE)
             memcpy(&num_pulses, file_buffer + buffer_idx + 0x6, sizeof(time))
             buffer_idx += 0x8
             for pulse in range(num_pulses):
-                _check_buffer_refill(fp, file_buffer, &buffer_idx, 0x5 * sizeof(char), BUFFER_SIZE,
-                                     timeout, &curr_file_size, filesize)
+                _check_buffer_refill(fp, file_buffer, &buffer_idx, 0x5 * sizeof(char), BUFFER_SIZE)
                 memcpy(&time, file_buffer + buffer_idx, sizeof(time))
                 memcpy(&width, file_buffer + buffer_idx + 0x2, sizeof(width))
                 memcpy(&intensity, file_buffer + buffer_idx + 0x3, sizeof(intensity))
@@ -223,26 +167,22 @@ cdef INT_t[:, :, :, :] _extract_bin(const char* filename, MAXINDEX_t filesize,
 @boundscheck(False) # Deactivate bounds checking
 @wraparound(False)  # Deactivate negative indexing
 @cdivision(True) # Ignore modulo/divide by zero warning
-cdef _extract_no_sum(const char* filename, MAXINDEX_t filesize, DTYPE_t low_range,
-                                    DTYPE_t high_range, int timeout=100):
+cdef _extract_no_sum(const char* filename, DTYPE_t low_range,
+                     DTYPE_t high_range):
     """ Creates histogram of observed peak widths within specified integration range
 
     Args:
         filename (const char*):
             Name of bin file to extract.
-        filesize (uint64_t):
-            Expected size of the bin file
         low_range (uint16_t):
             Low time range for integration
         high_range (uint16_t):
             High time range for integration
-        timeout (int):
-            How long to wait for downloading file (ms)
     """
     cdef DTYPE_t num_x, num_y, num_trig, num_frames, desc_len, trig, num_pulses, pulse, time
     cdef DTYPE_t intensity
     cdef SMALL_t width
-    cdef MAXINDEX_t data_start, pix, curr_file_size
+    cdef MAXINDEX_t data_start, pix 
     cdef int idx
 
     # 10MB buffer
@@ -252,20 +192,7 @@ cdef _extract_no_sum(const char* filename, MAXINDEX_t filesize, DTYPE_t low_rang
 
     # open file
     cdef FILE* fp
-    cdef int timer = 0
-    while True:
-        fp = fopen(filename, "rb")
-        if fp != NULL:
-            timer = 0
-            break
-        elif timer > timeout:
-            raise FileNotFoundError('Timer exceeded timeout of ' + str(timeout) +' seconds')
-        timer += 1
-        usleep(1)
-
-    fseek(fp, 0, SEEK_END)
-    curr_file_size = ftell(fp)
-    fseek(fp, 0, SEEK_SET)
+    fp = fopen(filename, "rb")
 
     # note, if cython has packed structs, this would be easier
     # or even macros tbh
@@ -289,13 +216,11 @@ cdef _extract_no_sum(const char* filename, MAXINDEX_t filesize, DTYPE_t low_rang
         #if pix % num_x == 0:
         #    print('\rpix done: ' + str(100 * pix / num_x / num_y) + '%...', end='')
         for trig in range(num_trig):
-            _check_buffer_refill(fp, file_buffer, &buffer_idx, 0x8 * sizeof(char), BUFFER_SIZE,
-                                 timeout, &curr_file_size, filesize)
+            _check_buffer_refill(fp, file_buffer, &buffer_idx, 0x8 * sizeof(char), BUFFER_SIZE)
             memcpy(&num_pulses, file_buffer + buffer_idx + 0x6, sizeof(time))
             buffer_idx += 0x8
             for pulse in range(num_pulses):
-                _check_buffer_refill(fp, file_buffer, &buffer_idx, 0x5 * sizeof(char), BUFFER_SIZE,
-                                     timeout, &curr_file_size, filesize)
+                _check_buffer_refill(fp, file_buffer, &buffer_idx, 0x5 * sizeof(char), BUFFER_SIZE)
                 memcpy(&time, file_buffer + buffer_idx, sizeof(time))
                 memcpy(&width, file_buffer + buffer_idx + 0x2, sizeof(width))
                 memcpy(&intensity, file_buffer + buffer_idx + 0x3, sizeof(intensity))
@@ -309,15 +234,15 @@ cdef _extract_no_sum(const char* filename, MAXINDEX_t filesize, DTYPE_t low_rang
     return np.copy(widths, order='C')
 
 
-def c_extract_bin(char* filename, MAXINDEX_t filesize, DTYPE_t[:] low_range,
-                  DTYPE_t[:] high_range, SMALL_t[:] calc_intensity, int timeout=100):
+def c_extract_bin(char* filename, DTYPE_t[:] low_range,
+                  DTYPE_t[:] high_range, SMALL_t[:] calc_intensity):
     return np.asarray(
-        _extract_bin(filename, filesize, low_range, high_range, calc_intensity, timeout)
+        _extract_bin(filename, low_range, high_range, calc_intensity)
     )
 
 
-def c_extract_no_sum(char* filename, MAXINDEX_t filesize, DTYPE_t low_range,
-                     DTYPE_t high_range, int timeout=100):
+def c_extract_no_sum(char* filename, DTYPE_t low_range,
+                     DTYPE_t high_range):
     return np.asarray(
-        _extract_no_sum(filename, filesize, low_range, high_range, timeout)
+        _extract_no_sum(filename, low_range, high_range)
     )

--- a/mibi_bin_tools/_extract_bin.pyx
+++ b/mibi_bin_tools/_extract_bin.pyx
@@ -3,8 +3,7 @@ from cython cimport cdivision, boundscheck, wraparound
 
 from libc.stdlib cimport malloc, free, realloc
 from libc.string cimport memcpy, memset
-from libc.stdio cimport fopen, fclose, FILE, EOF, fseek, SEEK_END, SEEK_SET, SEEK_CUR, fread, ftell, clearerr
-from posix.unistd cimport usleep
+from libc.stdio cimport fopen, fclose, FILE, EOF, fseek, SEEK_SET, SEEK_CUR, fread
 
 import numpy as np
 cimport numpy as np


### PR DESCRIPTION
.bin files could theoretically be read mid download previously.  However this functionality isn't needed now that Docker and google file-stream play nice.  

Furthermore, this feature hinders the readability of the cython code requires a lot of time-keeping related overhead.  This simplifies the code base a good bit. 