### PR TITLE
Handles Moly point failure on global panel extraction

### DIFF
--- a/mibi_bin_tools/bin_files.py
+++ b/mibi_bin_tools/bin_files.py
@@ -206,6 +206,11 @@ def _parse_global_panel(json_metadata: dict, fov: Dict[str, Any], panel: Tuple[f
         None:
             `fov` argument is modified in place
     """
+    if json_metadata['fov'].get('panel', None) is None:
+        raise KeyError(
+            f"'panel' field not found in {fov['json']}. "
+            + "If this is a moly point, you must manually supply a panel..."
+        )
     rows = json_metadata['fov']['panel']['conjugates']
     fov['masses'], fov['targets'] = zip(*[
         (el['mass'], el['target'])


### PR DESCRIPTION
Moly points don't have the 'panel' field in their json files. A dedicated error message is now shown when 'panel' is not found in the json.  Testing for this case is also implemented.  Closes issue #14 