### PR TITLE
Added `image_utils.save_image`

### DIFF
--- a/mibi_bin_tools/bin_files.py
+++ b/mibi_bin_tools/bin_files.py
@@ -8,6 +8,7 @@ import skimage.io as io
 import xarray as xr
 
 from mibi_bin_tools import io_utils, type_utils, _extract_bin
+from tmi.image_utils import save_image
 
 
 def _mass2tof(masses_arr: np.ndarray, mass_offset: float, mass_gain: float,
@@ -100,12 +101,8 @@ def _write_out(img_data: np.ndarray, out_dir: str, fov_name: str, targets: List[
             # save all first images regardless of replacing
             # if not replace (i=1), only save intensity images for specified targets
             if i == 0 or (target in list(intensities)):
-                io.imsave(
-                    os.path.join(out_dir_i, f'{target}{suffix}.tiff'),
-                    img_data[i, :, :, j].astype(save_dtype),
-                    plugin='tifffile',
-                    check_contrast=False
-                )
+                fname = os.path.join(out_dir_i, f"{target}{suffix}.tiff")
+                save_image(fname=fname, data=img_data[i, :, :, j].astype(save_dtype))
 
 
 def _find_bin_files(data_dir: str,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ matplotlib==3.4.3
 numpy>=1.21.6,<2
 pandas>=1.3.5,<2
 scikit-image>=0.19.3,<0.20
-tmi @ git+https://github.com/angelolab/tmi.git@dependencies/matplotlib
+tmi @ git+https://github.com/angelolab/tmi.git
 xarray>=2022.6.0,<2023

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ matplotlib==3.4.3
 numpy>=1.21.6,<2
 pandas>=1.3.5,<2
 scikit-image>=0.19.3,<0.20
+tmi @ git+https://github.com/angelolab/tmi.git@dependencies/matplotlib
 xarray>=2022.6.0,<2023


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #42.

**How did you implement your changes**

Adds tiff compression by default through using `tmi` as an extra dependency.

**Remaining issues**

- [ ] Merge the branch angelolab/tmi#12 in `tmi`, and set the dependency in toffy to point to the main branch of `tmi`.