### PR TITLE
GitHub Actions Updates, and Python 3.9+ Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.10, 3.11]
+        python-version: ["3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build_wheels:
-    name: ${{ github.repository }} ${{matrix.python-version}} wheels on ${{ matrix.os }}
+    name: ${{ matrix.os }} - ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails
@@ -43,7 +43,7 @@ jobs:
           path: wheelhouse/*.whl
 
   build_sdist:
-    name: Build ${{ github.repository }} Source Distribution
+    name: Source Distribution
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ${{ github.repository }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+        python-CIBW: []
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -31,6 +33,8 @@ jobs:
       - name: Build Wheels
         uses: pypa/cibuildwheel@v2.12.3
         with:
+          env:
+            CIBW_BUILD: "cp39-* cp310-* cp311-*"
           package-dir: .
           output-dir: wheelhouse
           config-file: "{package}/pyproject.toml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,12 @@ permissions:
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }} - ${{ matrix.python-version }}
+    name: ${{ matrix.os }} Wheels
     runs-on: ${{ matrix.os }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Wheel Builder
+name: Build
 
 on:
   workflow_call:
@@ -8,13 +8,14 @@ permissions:
 
 jobs:
   build_wheels:
-    name: Build  ${{ github.repository }} wheels on ${{ matrix.os }}
+    name: ${{ github.repository }} ${{matrix.python-version}} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-12]
+        python-version: [3.10, 3.11]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout ${{ github.repository }}
@@ -29,7 +30,7 @@ jobs:
           platforms: arm64
 
       - name: Build Wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.12.3
         with:
           package-dir: .
           output-dir: wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        python-CIBW: []
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -33,8 +32,6 @@ jobs:
       - name: Build Wheels
         uses: pypa/cibuildwheel@v2.12.3
         with:
-          env:
-            CIBW_BUILD: "cp39-* cp310-* cp311-*"
           package-dir: .
           output-dir: wheelhouse
           config-file: "{package}/pyproject.toml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
 
       - name: Download Coverage Artifact
         uses: actions/download-artifact@v3
-        with:
-          name: coverage
-          path: coverage
+        # if `name` is not specified, all artifacts are downloaded.
 
       - name: Upload Coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
           path: coverage
 
       - name: Upload Coverage to Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ github.workspace }}/coverage/coverage.lcov

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -40,17 +40,17 @@ jobs:
           name: distributions
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1.6
+      - uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          packages_dir: dist/
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
           verbose: true
 
   pypi_publish:
     name: Publish ${{ github.repository }} to to PyPI
-    needs: [test, build_wheels_sdist, test_pypi_publish]
+    needs: [test_pypi_publish]
 
     runs-on: ubuntu-latest
     # Publish when a GitHub Release is created, use the following rule:
@@ -63,9 +63,9 @@ jobs:
           path: dist
 
       - name: PYPI Publish
-        uses: pypa/gh-action-pypi-publish@release/v1.6
+        uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: dist/
+          packages-dir: dist/
           verbose: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     # branches to consider in the event; optional, defaults to all
-    branches: ["main"]
+    branches: [main]
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write # for release-drafter/release-drafter to add label to PR
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5.20.1
+      - uses: release-drafter/release-drafter@v5.23.0
         # Specify config name to use, relative to .github/. Default: release-drafter.yml
         with:
           config-name: release-drafter.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,14 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   test:
-    name: Test ${{ github.repository }}
-    runs-on: ubuntu-latest
+    name: ${{ github.repository }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Ensure that if any job fails, all jobs are cancelled.
+      fail-fast: false
+      matrix:
+        python-version: [3.10, 3.11]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout ${{ github.repository }}
@@ -16,10 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.8
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
           cache-dependency-path: "**/pyproject.toml"
           cache: "pip"
 
@@ -36,4 +42,4 @@ jobs:
         with:
           name: coverage
           path: |
-            coverage.lcov
+            coverage-${{ join(matrix.*, '-') }}.lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       # Ensure that if any job fails, all jobs are cancelled.
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   test:
-    name: ${{ github.repository }}
+    name: ${{ matrix.os }} - ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       # Ensure that if any job fails, all jobs are cancelled.
@@ -40,6 +40,6 @@ jobs:
       - name: Archive Coverage
         uses: actions/upload-artifact@v3
         with:
-          name: coverage
+          name: coverage-${{ join(matrix.*, '-') }}
           path: |
-            coverage-${{ join(matrix.*, '-') }}.lcov
+            coverage.lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       # Ensure that if any job fails, all jobs are cancelled.
       fail-fast: false
       matrix:
-        python-version: [3.10, 3.11]
+        python-version: ["3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 | | | 
 | ---        |    ---  |
-| CI / CD | [![CI](https://github.com/angelolab/mibi-bin-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/angelolab/mibi-bin-tools/actions/workflows/ci.yml) [![Coverage Status](https://coveralls.io/repos/github/angelolab/mibi-bin-tools/badge.svg?branch=master)](https://coveralls.io/github/angelolab/mibi-bin-tools?branch=master) |
+| CI / CD | [![CI](https://github.com/angelolab/mibi-bin-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/angelolab/mibi-bin-tools/actions/workflows/ci.yml) [![Coverage Status](https://coveralls.io/repos/github/angelolab/mibi-bin-tools/badge.svg?branch=main)](https://coveralls.io/github/angelolab/mibi-bin-tools?branch=main) |
 | Package | [![PyPI - Version](https://img.shields.io/pypi/v/mibi-bin-tools.svg?logo=pypi&label=PyPI&logoColor=gold)](https://pypi.org/project/mibi-bin-tools/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/mibi-bin-tools.svg?color=blue&label=Downloads&logo=pypi&logoColor=gold)](https://pypi.org/project/mibi-bin-tools/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mibi-bin-tools.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/mibi-bin-tools/) |
 |Meta | [![PyPI - License](https://img.shields.io/pypi/l/mibi-bin-tools?color=9400d3)](LICENSE) |
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,30 @@
-[![Build Status](https://travis-ci.com/angelolab/mibi-bin-tools.svg?branch=master)](https://travis-ci.com/angelolab/mibi-bin-tools)
-[![Coverage Status](https://coveralls.io/repos/github/angelolab/mibi-bin-tools/badge.svg?branch=master)](https://coveralls.io/github/angelolab/mibi-bin-tools?branch=master)
-
 # mibi-bin-tools
+<div align="center">
+
+| | | 
+| ---        |    ---  |
+| CI / CD | [![CI](https://github.com/angelolab/mibi-bin-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/angelolab/mibi-bin-tools/actions/workflows/ci.yml) [![Coverage Status](https://coveralls.io/repos/github/angelolab/mibi-bin-tools/badge.svg?branch=master)](https://coveralls.io/github/angelolab/mibi-bin-tools?branch=master) |
+| Package | [![PyPI - Version](https://img.shields.io/pypi/v/mibi-bin-tools.svg?logo=pypi&label=PyPI&logoColor=gold)](https://pypi.org/project/mibi-bin-tools/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/mibi-bin-tools.svg?color=blue&label=Downloads&logo=pypi&logoColor=gold)](https://pypi.org/project/mibi-bin-tools/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mibi-bin-tools.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/mibi-bin-tools/) |
+|Meta | [![PyPI - License](https://img.shields.io/pypi/l/mibi-bin-tools?color=9400d3)](LICENSE) |
+
+</div>
 
 Toolbox for extracting tiff images from MIBIScope .bin files 
 
-## To install the project:
+## Installation:
 
+### PyPI
+
+```sh
+pip install mibi-bin-tools
+```
+
+### Source
 Open terminal and navigate to where you want the code stored.
 
 Then input the command:
 
-```
+```sh
 git clone https://github.com/angelolab/mibi-bin-tools.git
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,11 @@ version_scheme = "release-branch-semver"
 local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
-build = ["cp310-*", "cp311-*"]
+build = ["cp39-*", "cp310-*", "cp311-*"]
 skip = [
     "cp36-*",        # Python 3.6
     "cp37-*",        # Python 3.7
     "cp38-*",        # Python 3.8
-    "cp39-*",        # Python 3.9
     "*-musllinux_*", # Musllinux
     "pp*",           # PyPy wheels on all platforms
     "*_i686",        # 32bit Linux Wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ skip = [
 ]
 
 build-frontend = "build"
-build-verbosity = 3
 
 # Avoid testing on emulated architectures
 test-skip = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,14 @@ dependencies = [
     "pandas>=1.3",
     "scikit-image>=0.19",
     "alpineer>=0.1.5",
-    "xarray>=2022"
+    "xarray>=2022",
 ]
 name = "mibi-bin-tools"
-authors = [{name = "Angelo Lab", email = "theangelolab@gmail.com"}]
+authors = [{ name = "Angelo Lab", email = "theangelolab@gmail.com" }]
 description = "Source for extracting .bin files from the commercial MIBI."
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "Modified Apache License 2.0"}
+license = { text = "Modified Apache License 2.0" }
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Cython",
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dynamic = ["version"]
-urls = {repository = "https://github.com/angelolab/mibi-bin-tools"}
+urls = { repository = "https://github.com/angelolab/mibi-bin-tools" }
 
 [project.optional-dependencies]
 test = [
@@ -44,7 +44,7 @@ test = [
     "pytest-cases",
     "pytest-cov",
     "pytest-mock",
-    "pytest-pycodestyle"
+    "pytest-pycodestyle",
 ]
 
 [tool.setuptools_scm]
@@ -54,16 +54,16 @@ local_scheme = "no-local-version"
 [tool.cibuildwheel]
 build = ["cp39-*", "cp310-*", "cp311-*"]
 skip = [
-    "cp36-*",        # Python 3.6
-    "cp37-*",        # Python 3.7
-    "cp38-*",        # Python 3.8
-    "*-musllinux_*", # Musllinux
-    "pp*",           # PyPy wheels on all platforms
-    "*_i686",        # 32bit Linux Wheels
-    "*_s390x",       # IBM System/390, "mainframe"
-    "*-win32",       # 32bit Windows Wheels
-    "*_ppc64le",     # PowerPC
-    "cp39-win_arm64",   # Windows ARM64 Python 3.9 wheels do not build.
+    "cp36-*",         # Python 3.6
+    "cp37-*",         # Python 3.7
+    "cp38-*",         # Python 3.8
+    "*-musllinux_*",  # Musllinux
+    "pp*",            # PyPy wheels on all platforms
+    "*_i686",         # 32bit Linux Wheels
+    "*_s390x",        # IBM System/390, "mainframe"
+    "*-win32",        # 32bit Windows Wheels
+    "*_ppc64le",      # PowerPC
+    "cp39-win_arm64", # Windows ARM64 Python 3.9 wheels do not build.
 ]
 
 build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,14 @@ name = "mibi-bin-tools"
 authors = [{name = "Angelo Lab", email = "theangelolab@gmail.com"}]
 description = "Source for extracting .bin files from the commercial MIBI."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "Modified Apache License 2.0"}
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Cython",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: Apache Software License",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
@@ -50,13 +51,12 @@ version_scheme = "release-branch-semver"
 local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
-build = ["cp38-*"]
+build = ["cp310-*", "cp311-*"]
 skip = [
     "cp36-*",        # Python 3.6
     "cp37-*",        # Python 3.7
+    "cp38-*",        # Python 3.8
     "cp39-*",        # Python 3.9
-    "cp310-*",       # Python 3.10
-    "cp311-*",       # Python 3.11
     "*-musllinux_*", # Musllinux
     "pp*",           # PyPy wheels on all platforms
     "*_i686",        # 32bit Linux Wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,13 @@ name = "mibi-bin-tools"
 authors = [{name = "Angelo Lab", email = "theangelolab@gmail.com"}]
 description = "Source for extracting .bin files from the commercial MIBI."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = {text = "Modified Apache License 2.0"}
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Cython",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ skip = [
     "*_s390x",       # IBM System/390, "mainframe"
     "*-win32",       # 32bit Windows Wheels
     "*_ppc64le",     # PowerPC
+    "cp39-win_arm64",   # Windows ARM64 Python 3.9 wheels do not build.
 ]
 
 build-frontend = "build"


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #52.

**How did you implement your changes**

- Added tests for `macos-latest`, `windows-latest` for Python 3.9, 3.10 and 3.11. The minimum Python version is now 3.9. 
- Updated several GitHub actions to their latest releases. 
- Coverage is combined for each OS / Python combination before being uploaded to coveralls. 
- Added some project badges which describe the supported python versions and the current package version number.

**Remaining issues**

Windows Arm 64 builds don't seem to work for Python 3.9, I've disabled them.