### PR TITLE
Next Release - v0.2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,12 @@ __pycache__/
 build/
 .pytest_cache/
 scripts/
-mibi_bin_tools/*.c
+src/**/*.c
 mibi_bin_tools/*.html
-mibi_bin_tools/*.so
+src/**/*.so
 *.egg-info
 .coverage
 htmlcov/
 .DS_Store
 .venv
+dist/

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,34 @@
-from os import pardir, path
-from setuptools import setup, Extension
-import numpy as np
+from pathlib import Path
 from Cython.Build import cythonize
+from Cython.Compiler.Options import get_directive_defaults
+from setuptools import Extension, setup
+import numpy as np
 
-CYTHON_DEBUG = False
+_compiler_directives = get_directive_defaults()
 
-if CYTHON_DEBUG:
-    from Cython.Compiler.Options import get_directive_defaults
-    
-    directive_defaults = get_directive_defaults()
-    directive_defaults["linetrace"] = True
-    directive_defaults["binding"] = True
+CYTHON_PROFILE_MODE = False
 
-CYTHON_MACROS = [("CYTHON_TRACE", "1")] if CYTHON_DEBUG else None
+CYTHON_MACROS: tuple[str,str] = None
 
-PKG_FOLDER = path.relpath(path.join(__file__, pardir))
+if CYTHON_PROFILE_MODE:
+    _compiler_directives["linetrace"] = True
+    _compiler_directives["profile"] = True
+    _compiler_directives["emit_code_comments"] = True
+    CYTHON_MACROS = [("CYTHON_TRACE", "1")]
+
+_compiler_directives["binding"] = True
+_compiler_directives["language_level"] = "3"
+_compiler_directives["embedsignature"] = True
 
 extensions = [
     Extension(
         name="mibi_bin_tools._extract_bin",
-        sources=[path.join(PKG_FOLDER, "src", "mibi_bin_tools", "_extract_bin.pyx")],
+        sources=[Path("src", "mibi_bin_tools", "_extract_bin.pyx").as_posix()],
         include_dirs=[np.get_include()],
         define_macros=CYTHON_MACROS
     )
 ]
 
 setup(
-    ext_modules=cythonize(extensions, compiler_directives={'language_level': "3"}),
+    ext_modules=cythonize(extensions, compiler_directives=_compiler_directives),
 )


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Creates a new release, with Python 3.9+ support.

**How did you implement your changes**

Added some paths in the `.gitignore`, updated the `setup.py`'s Cython build implementation to use the `compiler_directives`. 

**Remaining issues**

Similar to `pyFlowSOM`, Cython files do have coverage.