### PR TITLE
Truncate the mass range to time-of-flight conversion to ensure consistent range extraction

### DIFF
--- a/src/mibi_bin_tools/bin_files.py
+++ b/src/mibi_bin_tools/bin_files.py
@@ -54,6 +54,7 @@ def _set_tof_ranges(fov: Dict[str, Any], higher: np.ndarray, lower: np.ndarray,
     mass_ranges = (higher, lower)
 
     for key, masses, wrap in zip(key_names, mass_ranges):
+        # truncate the conversion to ensure consistency
         fov[key] = _mass2tof(
             masses, fov['mass_offset'], fov['mass_gain'], time_res
         ).astype(np.uint16)

--- a/src/mibi_bin_tools/bin_files.py
+++ b/src/mibi_bin_tools/bin_files.py
@@ -456,23 +456,13 @@ def get_median_pulse_height(data_dir: str, fov: str, channel: str,
 
     local_bin_file = os.path.join(data_dir, fov['bin'])
 
-    import timeit
-    start_time = timeit.default_timer()
     _, intensities, _ = \
         _extract_bin.c_extract_histograms(bytes(local_bin_file, 'utf-8'),
                                           fov['lower_tof_range'][0],
                                           fov['upper_tof_range'][0])
-    end_time = timeit.default_timer()
-    print("Total time to extract pulse height intensities: %.2f" % (end_time - start_time))
 
-    start_time = timeit.default_timer()
     int_bin = np.cumsum(intensities) / intensities.sum()
-    end_time = timeit.default_timer()
-    print("Total time to cumulatively sum pulse heights: %.2f" % (end_time - start_time))
-    start_time = timeit.default_timer()
     median_height = (np.abs(int_bin - 0.5)).argmin()
-    end_time = timeit.default_timer()
-    print("Total time to generate median position in cumsum pulse height arr: %.2f" % (end_time - start_time))
 
     return median_height
 

--- a/src/mibi_bin_tools/bin_files.py
+++ b/src/mibi_bin_tools/bin_files.py
@@ -53,7 +53,7 @@ def _set_tof_ranges(fov: Dict[str, Any], higher: np.ndarray, lower: np.ndarray,
     key_names = ('upper_tof_range', 'lower_tof_range')
     mass_ranges = (higher, lower)
 
-    for key, masses, wrap in zip(key_names, mass_ranges):
+    for key, masses in zip(key_names, mass_ranges):
         # truncate the conversion to ensure consistency
         fov[key] = _mass2tof(
             masses, fov['mass_offset'], fov['mass_gain'], time_res


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #55. Ensure that deficient and proficient windows respectively end and start at the same time-of-flight value.

**How did you implement your changes**

The `np.ceil` and `np.floor` conversion will not generate consistent windows given the same mass range value. Forcing truncation by converting using `.astype(np.uint16)` does the trick.