### PR TITLE
Fix the Windows build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           platforms: arm64
 
       - name: Build Wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.22.0
         with:
           package-dir: .
           output-dir: wheelhouse


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses part of #69, specifically the Windows builds failing.

**How did you implement your changes**

Needed to update `cibuildwheel` to be the latest version.