### PR TITLE
Bump `upload-artifact` and `download-artifact` GA to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           config-file: "{package}/pyproject.toml"
 
       - name: Store Wheel Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: distributions
           path: wheelhouse/*.whl
@@ -55,7 +55,7 @@ jobs:
         run: pipx run twine check dist/*
 
       - name: Store sdist Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: distributions
           path: dist/*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download Coverage Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         # if `name` is not specified, all artifacts are downloaded.
 
       - name: Upload Coverage to Coveralls

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -35,7 +35,7 @@ jobs:
     needs: [test, build_wheels_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: distributions
           path: dist
@@ -57,7 +57,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: distributions
           path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           pytest
 
       - name: Archive Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ join(matrix.*, '-') }}
           path: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,7 @@ test-skip = [
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 
-
-# On an Linux Intel runner with qemu installed, build Intel and aarch64 (arm) wheels
+# On a Linux Intel runner with qemu installed, build Intel and aarch64 (arm) wheels
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
 repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"


### PR DESCRIPTION
**What is the purpose of this PR?**

v3 of the artifact GAs have been deprecated, so they need to be bumped.