### PR TITLE
Bump Python version: remove 3.10 and support 3.12-3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           platforms: arm64
 
       - name: Build Wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       # Ensure that if any job fails, all jobs are cancelled.
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache-dependency-path: "**/pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,17 +2,17 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=3",
-    "oldest-supported-numpy",
+    "Cython>=3.2",
+    "numpy>=2.1",
     "setuptools_scm[toml]>=6.2",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 dependencies = [
-    "Cython>=3",
+    "Cython>=3.2",
     "matplotlib>=3",
-    "numpy>=1.25",
+    "numpy>=2.1",
     "pandas>=2",
     "scikit-image>=0.19",
     "alpineer>=0.1.9",
@@ -22,16 +22,16 @@ name = "mibi-bin-tools"
 authors = [{ name = "Angelo Lab", email = "theangelolab@gmail.com" }]
 description = "Source for extracting .bin files from the commercial MIBI."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11,<3.15"
 license = { text = "Modified Apache License 2.0" }
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Cython",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: Apache Software License",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
@@ -53,18 +53,19 @@ version_scheme = "release-branch-semver"
 local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+build = ["cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 skip = [
     "cp36-*",         # Python 3.6
     "cp37-*",         # Python 3.7
     "cp38-*",         # Python 3.8
+    "cp39-*",         # Python 3.9
+    "cp310-*",        # Python 3.10
     "*-musllinux_*",  # Musllinux
     "pp*",            # PyPy wheels on all platforms
     "*_i686",         # 32bit Linux Wheels
     "*_s390x",        # IBM System/390, "mainframe"
     "*-win32",        # 32bit Windows Wheels
     "*_ppc64le",      # PowerPC
-    "cp39-win_arm64", # Windows ARM64 Python 3.9 wheels do not build.
 ]
 
 build-frontend = "build"


### PR DESCRIPTION
**What is the purpose of this PR?**

Python 3.10 will reach EOL in two months. Additionally, Python versions have upgraded significantly since our last refactor, now supporting versions 3.12-3.14. We need to do an org-wide refactor to support this. `mibi-bin-tools` is a "golden dependency" (meaning it doesn't depend on anything else in `angelolab`, while others depend on it). So it will be a good place to start.